### PR TITLE
feat: 회원가입 기능 구현 및 보안 강화

### DIFF
--- a/src/main/java/com/example/racetobuy/controller/MemberController.java
+++ b/src/main/java/com/example/racetobuy/controller/MemberController.java
@@ -1,0 +1,32 @@
+package com.example.racetobuy.controller;
+
+import com.example.racetobuy.domain.member.dto.MemberSignupRequest;
+import com.example.racetobuy.global.util.ApiResponse;
+import com.example.racetobuy.service.member.AuthService;
+import com.example.racetobuy.service.member.AuthServiceImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final AuthService authService;
+
+    /**
+     * 회원가입 요청을 처리합니다.
+     * @param request 사용자 회원가입 요청 정보
+     * @return ApiResponse 성공 또는 실패 응답
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse> signup(@Valid @RequestBody MemberSignupRequest request) {
+        ApiResponse response = authService.signup(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/racetobuy/domain/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/example/racetobuy/domain/member/dto/MemberSignupRequest.java
@@ -1,0 +1,29 @@
+package com.example.racetobuy.domain.member.dto;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class MemberSignupRequest {
+
+    @NotBlank(message = "이름은 필수 입력값입니다.")
+    @Size(min = 2, max = 50, message = "이름은 2~50자 사이여야 합니다.")
+    private String username;
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    @Size(min = 8, max = 100, message = "비밀번호는 8~100자 사이여야 합니다.")
+    private String password;
+
+    @NotBlank(message = "주소는 필수 입력값입니다.")
+    private String address;
+
+    @NotBlank(message = "전화번호는 필수 입력값입니다.")
+    private String phoneNumber;
+}

--- a/src/main/java/com/example/racetobuy/domain/member/entity/Member.java
+++ b/src/main/java/com/example/racetobuy/domain/member/entity/Member.java
@@ -1,4 +1,4 @@
-package com.example.racetobuy.domain.member;
+package com.example.racetobuy.domain.member.entity;
 
 import com.example.racetobuy.domain.order.Order;
 import com.example.racetobuy.domain.timestamp.TimeStamp;
@@ -31,10 +31,10 @@ public class Member extends TimeStamp {
     @Column(name = "password", nullable = false, length = 255)
     private String password;
 
-    @Column(name = "phone_number", length = 20)
+    @Column(name = "phone_number", nullable = false, length = 20)
     private String phoneNumber;
 
-    @Column(name = "address", columnDefinition = "TEXT")
+    @Column(name = "address", nullable = false, columnDefinition = "TEXT")
     private String address;
 
     @OneToMany(mappedBy = "member")
@@ -42,5 +42,13 @@ public class Member extends TimeStamp {
 
     @OneToMany(mappedBy = "member")
     private List<Wishlist> wishlists = new ArrayList<>();
+
+    public Member(String username, String email, String password, String phoneNumber, String address) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+    }
 
 }

--- a/src/main/java/com/example/racetobuy/domain/member/entity/MemberSecureData.java
+++ b/src/main/java/com/example/racetobuy/domain/member/entity/MemberSecureData.java
@@ -1,0 +1,44 @@
+package com.example.racetobuy.domain.member.entity;
+
+import com.example.racetobuy.domain.timestamp.TimeStamp;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "member_secure_data")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberSecureData extends TimeStamp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_secure_data_id")
+    private Long memberSecureDataId; // 기본 키 (AUTO_INCREMENT)
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
+    private Member member; // Member 테이블과의 외래 키 관계 (1:1 관계)
+
+    @Column(name = "email_hash", nullable = false, unique = true, length = 255)
+    private String emailHash; // 이메일 해시 (고유 제약 조건)
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash; // 비밀번호 해시 (SHA 또는 BCrypt 해시값)
+
+    @Column(name = "name_hash", nullable = false, length = 255)
+    private String nameHash; // 이름 해시 (SHA-256 해시값)
+
+    @Column(name = "address_hash", nullable = false, length = 255)
+    private String addressHash; // 주소 해시 (SHA-256 해시값)
+
+    // 엔티티 생성 메서드
+    public MemberSecureData(Member member, String emailHash, String passwordHash, String nameHash, String addressHash) {
+        this.member = member;
+        this.emailHash = emailHash;
+        this.passwordHash = passwordHash;
+        this.nameHash = nameHash;
+        this.addressHash = addressHash;
+    }
+}

--- a/src/main/java/com/example/racetobuy/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/racetobuy/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.example.racetobuy.domain.member.repository;
+
+import com.example.racetobuy.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/example/racetobuy/domain/member/repository/MemberSecureDataRepository.java
+++ b/src/main/java/com/example/racetobuy/domain/member/repository/MemberSecureDataRepository.java
@@ -1,0 +1,8 @@
+package com.example.racetobuy.domain.member.repository;
+
+import com.example.racetobuy.domain.member.entity.MemberSecureData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberSecureDataRepository extends JpaRepository<MemberSecureData, Long> {
+    boolean existsByEmailHash(String email);
+}

--- a/src/main/java/com/example/racetobuy/domain/order/Order.java
+++ b/src/main/java/com/example/racetobuy/domain/order/Order.java
@@ -1,6 +1,6 @@
 package com.example.racetobuy.domain.order;
 
-import com.example.racetobuy.domain.member.Member;
+import com.example.racetobuy.domain.member.entity.Member;
 import com.example.racetobuy.domain.timestamp.TimeStamp;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/example/racetobuy/domain/wishlist/Wishlist.java
+++ b/src/main/java/com/example/racetobuy/domain/wishlist/Wishlist.java
@@ -1,6 +1,6 @@
 package com.example.racetobuy.domain.wishlist;
 
-import com.example.racetobuy.domain.member.Member;
+import com.example.racetobuy.domain.member.entity.Member;
 import com.example.racetobuy.domain.product.Product;
 import com.example.racetobuy.domain.timestamp.TimeStamp;
 import jakarta.persistence.*;

--- a/src/main/java/com/example/racetobuy/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/racetobuy/global/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.example.racetobuy.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration  // 설정 클래스
+public class SecurityConfig {
+
+    @Bean  // BCryptPasswordEncoder를 Bean으로 등록
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf(AbstractHttpConfigurer::disable);
+        httpSecurity.httpBasic(AbstractHttpConfigurer::disable);
+        httpSecurity.headers(c1 -> c1.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
+        httpSecurity.cors(c -> c.configurationSource(configurationSource()));
+        httpSecurity.sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        httpSecurity.formLogin(AbstractHttpConfigurer::disable);
+
+        httpSecurity.authorizeHttpRequests((request) -> request
+                .requestMatchers(new AntPathRequestMatcher("/api/members/signup/**")
+                ).permitAll()
+                .anyRequest().authenticated());
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource configurationSource() {
+
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*"); // GET, POST, PUT, DELETE (Javascript 요청 허용)
+        configuration.addAllowedOriginPattern("*"); // 모든 IP 주소 허용 (프론트 앤드 IP만 허용 react)
+        configuration.setAllowCredentials(true); // 클라이언트에서 쿠키 요청 허용
+//        configuration.addExposedHeader("Authorization"); // 옛날에는 디폴트 였다. 지금은 아닙니다.
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/example/racetobuy/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/racetobuy/global/constant/ErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "로그인 후 이용해주세요."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
-    LOGIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "로그인에 실패했습니다. 다시 시도해주세요.");
+    LOGIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "로그인에 실패했습니다. 다시 시도해주세요."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/racetobuy/global/util/AESUtil.java
+++ b/src/main/java/com/example/racetobuy/global/util/AESUtil.java
@@ -1,0 +1,56 @@
+package com.example.racetobuy.global.util;
+
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class AESUtil {
+
+    private static final String KEY = "1234567890123456"; // 16자리 고정 키
+
+    // AES 암호화
+    public String encrypt(String value) {
+        try {
+            byte[] ivBytes = new byte[16];
+            new SecureRandom().nextBytes(ivBytes); // 랜덤 IV 생성
+            IvParameterSpec ivSpec = new IvParameterSpec(ivBytes);
+
+            SecretKeySpec secretKey = new SecretKeySpec(KEY.getBytes(), "AES");
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivSpec);
+
+            byte[] encryptedBytes = cipher.doFinal(value.getBytes());
+
+            // IV와 암호문을 Base64로 인코딩 후 결합
+            return Base64.getEncoder().encodeToString(ivBytes) + ":" + Base64.getEncoder().encodeToString(encryptedBytes);
+        } catch (Exception e) {
+            throw new RuntimeException("암호화에 실패했습니다.", e);
+        }
+    }
+
+
+    // AES 복호화
+    public String decrypt(String encryptedValue) {
+        try {
+            String[] parts = encryptedValue.split(":");
+            byte[] ivBytes = Base64.getDecoder().decode(parts[0]);
+            byte[] encryptedBytes = Base64.getDecoder().decode(parts[1]);
+
+            IvParameterSpec ivSpec = new IvParameterSpec(ivBytes);
+            SecretKeySpec secretKey = new SecretKeySpec(KEY.getBytes(), "AES");
+
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec);
+
+            byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+            return new String(decryptedBytes);
+        } catch (Exception e) {
+            throw new RuntimeException("복호화에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/example/racetobuy/global/util/SHA256Util.java
+++ b/src/main/java/com/example/racetobuy/global/util/SHA256Util.java
@@ -1,0 +1,20 @@
+package com.example.racetobuy.global.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class SHA256Util {
+    public static String hash(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = md.digest(input.getBytes());
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hashBytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 해시 생성에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/example/racetobuy/service/member/AuthService.java
+++ b/src/main/java/com/example/racetobuy/service/member/AuthService.java
@@ -1,0 +1,8 @@
+package com.example.racetobuy.service.member;
+
+import com.example.racetobuy.domain.member.dto.MemberSignupRequest;
+import com.example.racetobuy.global.util.ApiResponse;
+
+public interface AuthService {
+    ApiResponse<?> signup(MemberSignupRequest request);
+}

--- a/src/main/java/com/example/racetobuy/service/member/AuthServiceImpl.java
+++ b/src/main/java/com/example/racetobuy/service/member/AuthServiceImpl.java
@@ -1,0 +1,60 @@
+package com.example.racetobuy.service.member;
+
+import com.example.racetobuy.domain.member.dto.MemberSignupRequest;
+import com.example.racetobuy.domain.member.entity.Member;
+import com.example.racetobuy.domain.member.entity.MemberSecureData;
+import com.example.racetobuy.domain.member.repository.MemberRepository;
+import com.example.racetobuy.domain.member.repository.MemberSecureDataRepository;
+import com.example.racetobuy.global.constant.ErrorCode;
+import com.example.racetobuy.global.util.AESUtil;
+import com.example.racetobuy.global.util.ApiResponse;
+import com.example.racetobuy.global.util.SHA256Util;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final MemberRepository memberRepository;
+    private final MemberSecureDataRepository memberSecureDataRepository;
+    private final AESUtil aesUtil;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public ApiResponse<?> signup(MemberSignupRequest request) {
+
+        String emailHash = SHA256Util.hash(request.getEmail());
+
+        boolean isEmailExists = memberSecureDataRepository.existsByEmailHash(emailHash);
+        if (isEmailExists) {
+            return ApiResponse.createException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        // 데이터 암호화
+        String encryptedEmail = aesUtil.encrypt(request.getEmail());
+        String encryptedName = aesUtil.encrypt(request.getUsername());
+        String encryptedAddress = aesUtil.encrypt(request.getAddress());
+        String encryptedPassword = passwordEncoder.encode(request.getPassword());
+
+        // 회원 엔티티 생성 및 저장
+        Member member = new Member(encryptedName, encryptedEmail, encryptedPassword, request.getPhoneNumber(), encryptedAddress);
+        memberRepository.save(member);
+
+        // MemberSecureData 생성 및 저장
+        MemberSecureData memberSecureData = new MemberSecureData(
+                member,
+                emailHash,
+                encryptedPassword,
+                SHA256Util.hash(request.getUsername()),
+                SHA256Util.hash(request.getAddress())
+        );
+        memberSecureDataRepository.save(memberSecureData);
+
+        // 응답 반환
+        return ApiResponse.createSuccess();
+    }
+}


### PR DESCRIPTION
- **회원가입 기능 추가**
  - `/api/members/signup` 경로에 회원가입 API 추가 (MemberController 생성)
  - `MemberSignupRequest` DTO 추가 (유효성 검증을 위한 @Valid 어노테이션 사용)
  - `AuthService` 인터페이스 및 `AuthServiceImpl` 구현체 추가
  - 신규 회원 정보 저장 로직 추가 (MemberRepository, MemberSecureDataRepository 활용)

- **데이터 보안 강화**
  - **AESUtil 추가**: 이메일, 이름, 주소에 대한 AES 암호화 기능 구현
  - **SHA256Util 추가**: 사용자 정보(이메일, 이름, 주소) 해시 생성 로직 추가
  - **BCrypt 적용**: 비밀번호는 `BCryptPasswordEncoder`로 해시화하여 저장

- **Member 엔티티 변경**
  - 회원 생성자 추가 (이름, 이메일, 비밀번호, 전화번호, 주소)

- **MemberSecureData 엔티티 추가**
  - 회원의 민감한 정보를 해시 형태로 저장하는 테이블 추가
  - 회원과 1:1 매핑 (`@OneToOne` 관계)으로 설계

- **에러 코드 추가**
  - **EMAIL_ALREADY_EXISTS**: 이미 존재하는 이메일에 대한 에러 메시지 추가

- **보안 설정 추가**
  - **SecurityConfig**: 회원가입 경로에 대해 인증 없이 접근 가능하도록 설정
  - **BCryptPasswordEncoder Bean 등록**: 비밀번호 인코딩을 위해 `BCryptPasswordEncoder` 등록

- **리포지토리 추가**
  - `MemberRepository` 추가: `Member` 엔티티에 대한 기본 CRUD 작업
  - `MemberSecureDataRepository` 추가: `existsByEmailHash` 메서드 추가로 이메일 중복 검사 로직 구현

 Ref: #3