### PR TITLE
feat: Refresh Token 기능 추가 및 관련 로직 수정

### DIFF
--- a/src/main/java/com/example/racetobuy/controller/MemberController.java
+++ b/src/main/java/com/example/racetobuy/controller/MemberController.java
@@ -119,4 +119,9 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/refresh")
+    public ApiResponse<?> refreshAccessToken(@RequestHeader("Refresh-Token") String refreshToken) {
+        return authService.refreshAccessToken(refreshToken);
+    }
+
 }

--- a/src/main/java/com/example/racetobuy/domain/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/example/racetobuy/domain/member/dto/MemberSignupRequest.java
@@ -1,6 +1,7 @@
 package com.example.racetobuy.domain.member.dto;
 
 
+import com.example.racetobuy.global.constant.RoleToken;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -26,4 +27,14 @@ public class MemberSignupRequest {
 
     @NotBlank(message = "전화번호는 필수 입력값입니다.")
     private String phoneNumber;
+
+    @NotBlank(message = "룰은 필수 입력값입니다.")
+    private String role;
+
+    /**
+     * Role을 Enum으로 변환하여 반환
+     */
+    public RoleToken getRoleToken() {
+        return RoleToken.findByName(this.role);
+    }
 }

--- a/src/main/java/com/example/racetobuy/domain/member/entity/Member.java
+++ b/src/main/java/com/example/racetobuy/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.example.racetobuy.domain.member.entity;
 import com.example.racetobuy.domain.order.Order;
 import com.example.racetobuy.domain.timestamp.TimeStamp;
 import com.example.racetobuy.domain.wishlist.Wishlist;
+import com.example.racetobuy.global.constant.RoleToken;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
@@ -44,6 +45,10 @@ public class Member extends TimeStamp {
     @Column(name = "address", nullable = false, columnDefinition = "TEXT")
     private String address;
 
+    @Enumerated(EnumType.STRING) // Enum을 String으로 매핑
+    @Column(name = "role", nullable = false, length = 10)
+    private RoleToken role;
+
     @OneToMany(mappedBy = "member")
     private List<Order> orders = new ArrayList<>();
 
@@ -51,18 +56,22 @@ public class Member extends TimeStamp {
     private List<Wishlist> wishlists = new ArrayList<>();
 
     @Builder
-    public Member(Long memberId,String username, String email, String password, String phoneNumber, String address) {
+    public Member(Long memberId, String username, String email, String password, String phoneNumber, String address, RoleToken role) {
         this.memberId = memberId;
         this.username = username;
         this.email = email;
         this.password = password;
         this.phoneNumber = phoneNumber;
         this.address = address;
+        this.role = role;
     }
 
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
 
+    public void updateRole(RoleToken newRole) { // Role 업데이트 메서드
+        this.role = newRole;
+    }
 
 }

--- a/src/main/java/com/example/racetobuy/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/racetobuy/domain/member/repository/RefreshTokenRepository.java
@@ -15,5 +15,13 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     @Modifying
     @Transactional
     void deleteAllByMember_MemberId(Long memberId);
+
+    /**
+     * Member ID로 리프레시 토큰 조회
+     *
+     * @param memberId 회원 ID
+     * @return 리프레시 토큰(Optional)
+     */
+    Optional<RefreshToken> findByMember_MemberId(Long memberId);
 }
 

--- a/src/main/java/com/example/racetobuy/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/racetobuy/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.racetobuy.global.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -42,6 +43,18 @@ public class SecurityConfig {
                 .requestMatchers(new AntPathRequestMatcher("/auth/**"),
                         new AntPathRequestMatcher("/login/**")
                 ).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/refresh"))
+                .access((authentication, context) -> {
+                    // 헤더에서 Refresh-Token 가져오기
+                    String refreshToken = context.getRequest().getHeader("Refresh-Token");
+
+                    // Refresh-Token 검증 로직 (단순히 null 체크 예시)
+                    if (refreshToken != null && !refreshToken.trim().isEmpty()) {
+                        return new AuthorizationDecision(true); // 접근 허용
+                    } else {
+                        return new AuthorizationDecision(false); // 접근 거부
+                    }
+                })
                 .anyRequest().authenticated());
 
         httpSecurity.logout(httpSecurityLogoutConfigurer -> httpSecurityLogoutConfigurer.disable());

--- a/src/main/java/com/example/racetobuy/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/racetobuy/global/constant/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
     PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다."),
     AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "인증 정보가 필요합니다."),
+    REFRESH_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 블랙리스트에 등록되었습니다."),
 
 
 

--- a/src/main/java/com/example/racetobuy/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/racetobuy/global/security/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.example.racetobuy.global.security;
 
 import com.example.racetobuy.domain.member.entity.Member;
 import com.example.racetobuy.global.constant.ErrorCode;
+import com.example.racetobuy.global.constant.RoleToken;
 import com.example.racetobuy.global.exception.BusinessException;
 import com.example.racetobuy.global.util.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -27,6 +29,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -41,10 +44,40 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         jwt = jwt.replace(JwtTokenProvider.TOKEN_PREFIX, "");
 
+        // Redis 블랙리스트 확인
+        if (isTokenBlacklisted(jwt)) {
+            log.error("JWT Token is blacklisted: {}", jwt);
+            setErrorResponse(response, new BusinessException(ErrorCode.JWT_INVALID));
+            return;
+        }
+
         try {
             // JWT 토큰 검증
             if (!jwtTokenProvider.validateToken(jwt)) {
                 filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 토큰 타입 확인
+            String tokenType = jwtTokenProvider.getTokenType(jwt);
+
+            if ("REFRESH".equals(tokenType)) {
+                // 리프레시 토큰은 별도의 처리로직
+                processRefreshToken(jwt);
+                filterChain.doFilter(request, response); // 리프레시 토큰 처리 후 다음 필터로 전달
+                return;
+            } else if ("ACCESS".equals(tokenType)) {
+                // 액세스 토큰 처리
+                try {
+                    processAccessToken(jwt, request);
+                }catch (Exception e){
+                    log.error("Authentication Error: {}", e.getMessage());
+                    setErrorResponse(response, new BusinessException(ErrorCode.JWT_INVALID));
+                    return;
+                }
+            } else {
+                log.error("Invalid Token Type: {}", tokenType);
+                setErrorResponse(response, new BusinessException(ErrorCode.JWT_INVALID));
                 return;
             }
 
@@ -54,31 +87,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        // JWT에서 사용자 정보 추출
-        try {
-            Long memberId = jwtTokenProvider.getMemberIdFromToken(jwt);
-            String email = jwtTokenProvider.getEmailFromToken(jwt);
-
-            //Member 객체 생성
-            Member member = Member.builder()
-                    .memberId(memberId)
-                    .email(email)
-                    .build();
-
-            MemberDetails memberDetails = new MemberDetails(member);
-
-            //Spring Security에 인증 정보 설정
-            UsernamePasswordAuthenticationToken authenticationToken =
-                    new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities());
-
-            authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-
-        } catch (Exception e) {
-            log.error("Authentication Error: {}", e.getMessage());
-            setErrorResponse(response, new BusinessException(ErrorCode.JWT_INVALID));
-            return;
-        }
 
         // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
@@ -99,5 +107,49 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         servletResponse.setContentType("application/json; charset=utf-8");
         String body = mapper.writeValueAsString(response);
         servletResponse.getOutputStream().write(body.getBytes());
+    }
+
+    private boolean isTokenBlacklisted(String jwt) {
+        String blacklistKey = "BLACKLIST_TOKEN:" + jwt;
+        return redisTemplate.opsForValue().get(blacklistKey) != null;
+    }
+
+    // 액세스 토큰 처리
+    private void processAccessToken(String jwt, HttpServletRequest request) {
+        Long memberId = jwtTokenProvider.getMemberIdFromToken(jwt);
+        String email = jwtTokenProvider.getEmailFromToken(jwt);
+        String role = jwtTokenProvider.getRoleFromToken(jwt);
+
+        RoleToken roleToken = RoleToken.findByName(role);
+
+        Member member = Member.builder()
+                .memberId(memberId)
+                .email(email)
+                .role(roleToken)
+                .build();
+
+        MemberDetails memberDetails = new MemberDetails(member);
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities());
+
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+
+    // 리프레시 토큰 처리
+    private void processRefreshToken(String jwt) {
+        // 리프레시 토큰은 인증 컨텍스트에 추가하지 않고 단순히 유효성을 확인하는 수준에서 처리
+        if (!jwtTokenProvider.validateRefreshToken(jwt)) {
+            throw new BusinessException(ErrorCode.JWT_INVALID);
+        }
+        // 블랙리스트 확인
+        if (isTokenBlacklisted(jwt)) {
+            log.error("Refresh Token is blacklisted: {}", jwt);
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_BLACKLISTED);
+        }
+
+        // 리프레시 토큰 처리 로직 추가 (필요 시 확장)
+        log.info("Refresh Token is valid: {}", jwt);
     }
 }

--- a/src/main/java/com/example/racetobuy/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/racetobuy/global/security/JwtTokenProvider.java
@@ -12,13 +12,14 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.security.SignatureException;
 import java.util.Date;
 
 
 @Component
 public class JwtTokenProvider {
     public static final Long REFRESH_EXP = 1000L * 60 * 60 * 24 * 7;
-    public static final Long ACCESS_EXP = 1000L * 60 * 60;
+    public static final Long ACCESS_EXP = 1000L * 60 * 60 * 24;
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String HEADER = "Authorization";
 
@@ -39,6 +40,7 @@ public class JwtTokenProvider {
         claims.put("id", member.getMemberId());
         claims.put("email", member.getEmail());
         claims.put("role", roleToken.getName()); // 역할 추가
+        claims.put("type", "ACCESS");
 
         String jwt = Jwts.builder()
                 .setClaims(claims)
@@ -53,10 +55,12 @@ public class JwtTokenProvider {
     /**
      * 🔥 RefreshToken 생성 메서드
      */
-    public String createRefreshToken(Member member) {
+    public String createRefreshToken(Member member, String role) {
         Claims claims = Jwts.claims();
         claims.put("id", member.getMemberId());
         claims.put("email", member.getEmail());
+        claims.put("role", role);
+        claims.put("type", "REFRESH");
 
         String jwt = Jwts.builder()
                 .setClaims(claims)
@@ -108,13 +112,66 @@ public class JwtTokenProvider {
 
     // 액세스 토큰의 만료 시간 (만료 시간 반환)
     public long getExpiration(String token) {
-        Claims claims = Jwts.parser()
-                .setSigningKey(secretKey) // 시크릿 키로 서명 확인
-                .parseClaimsJws(token) // 토큰 파싱
-                .getBody(); // Claims(페이로드) 가져오기
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return claims.getExpiration().getTime(); // 만료 시간 반환
+        } catch (Exception e) {
+            System.out.println("Failed to parse JWT: {}" + e.getMessage());
+            throw new JwtException(ErrorCode.JWT_INVALID);
+        }
+    }
 
-        // 'exp'는 JWT의 만료 시간 (Unix Time)으로, 밀리초 단위로 반환
-        return claims.getExpiration().getTime();
+    public String getRoleFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.get("role", String.class);
+    }
+
+    // 토큰 타입 반환
+    public String getTokenType(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.get("type", String.class); // "type" 클레임에서 값 추출
+    }
+
+    // Refresh Token 유효성 확인
+    public boolean validateRefreshToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            // "type" 클레임이 "REFRESH"인지 확인
+            String type = claims.get("type", String.class);
+            if (!"REFRESH".equals(type)) {
+                return false;
+            }
+
+            // 토큰 만료 여부 확인
+            Date expiration = claims.getExpiration();
+            if (expiration.before(new Date())) {
+                return false; // 토큰이 만료됨
+            }
+            return true;
+        } catch (JwtException e) {
+            System.out.println("Invalid Refresh Token: {}" + e.getMessage());
+            return false; // 서명 오류
+        } catch (Exception e) {
+            System.out.println("Refresh Token Validation Error: {}" + e.getMessage());
+            return false; // 기타 오류
+        }
     }
 
 

--- a/src/main/java/com/example/racetobuy/service/member/AuthService.java
+++ b/src/main/java/com/example/racetobuy/service/member/AuthService.java
@@ -65,4 +65,11 @@ public interface AuthService {
      */
     ApiResponse<?> logoutAllDevices(String accessToken);
 
+    /**
+     * 리플레쉬 토큰존재시 액세스 토큰 자동 발급
+     *
+     * @param refreshToken  토큰
+     * @return 성공 응답
+     */
+    ApiResponse<?> refreshAccessToken(String refreshToken);
 }


### PR DESCRIPTION
- AuthService에 refreshAccessToken 메서드 추가
- JwtTokenProvider에 Refresh Token 생성 및 검증 로직 추가
- Member 엔티티에 Role 필드 추가 및 업데이트 메서드 추가
- MemberSignupRequest DTO에 Role 처리 로직 추가
- RefreshTokenRepository에 Member ID로 토큰 조회 기능 추가
- JwtAuthenticationFilter에서 Refresh Token 검증 및 블랙리스트 로직 추가
- ErrorCode에 Refresh Token 관련 에러 코드 추가
- SecurityConfig에 Refresh Token 접근 권한 로직 추가
- MemberController에 Refresh Token 처리 엔드포인트 추가
- 관련 테스트 및 Redis 블랙리스트 연동 검증 완료