### PR TITLE
fix: Redis Refresh Token Blacklist 처리 오류 수정

### DIFF
--- a/src/main/java/com/example/racetobuy/domain/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/example/racetobuy/domain/member/dto/MemberSignupRequest.java
@@ -2,12 +2,14 @@ package com.example.racetobuy.domain.member.dto;
 
 
 import com.example.racetobuy.global.constant.RoleToken;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MemberSignupRequest {
 
     @NotBlank(message = "이름은 필수 입력값입니다.")

--- a/src/main/java/com/example/racetobuy/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/racetobuy/global/security/JwtTokenProvider.java
@@ -113,6 +113,10 @@ public class JwtTokenProvider {
     // 액세스 토큰의 만료 시간 (만료 시간 반환)
     public long getExpiration(String token) {
         try {
+            // Bearer로 시작하면 제거
+            if (token.startsWith("Bearer ")) {
+                token = token.substring(7); // "Bearer " 이후의 문자열 추출
+            }
             Claims claims = Jwts.parserBuilder()
                     .setSigningKey(secretKey)
                     .build()


### PR DESCRIPTION
- Redis에서 Refresh Token 블랙리스트 처리 시 "Bearer " 접두사를 제거하도록 로직 수정
- Refresh Token 만료 시간 계산 오류 수정
- JwtTokenProvider에서 Bearer 접두사 처리 로직 추가
- 불필요한 토큰 유효성 검사 로직 최적화
- @JsonIgnoreProperties 추가로 JSON 매핑 중 알 수 없는 속성 무시하도록 수정

Ref: #11 