### PR TITLE
feat: 상품 조회 실패 시 에러 처리 로직 추가 및 상품 관련 엔티티 업데이트

### DIFF
--- a/src/main/java/com/example/racetobuy/controller/ProductController.java
+++ b/src/main/java/com/example/racetobuy/controller/ProductController.java
@@ -1,0 +1,52 @@
+package com.example.racetobuy.controller;
+
+import com.example.racetobuy.domain.page.PagedResponseDTO;
+import com.example.racetobuy.domain.product.dto.ProductWithEventDTO;
+import com.example.racetobuy.service.product.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    /**
+     * 커서 기반 페이지네이션을 사용하여 상품 목록을 조회합니다.
+     *
+     * @param cursor 현재 페이지를 결정하는 커서 값 (0이면 첫 페이지를 의미)
+     * @param size   한 페이지에 표시할 상품 수 (기본값: 10)
+     * @return PagedResponseDTO<ProductWithEventDTO> 상품 목록 및 다음 커서 정보
+     *
+     * 예시 요청:
+     * GET /products?cursor=1&size=5
+     * 응답: 지정된 커서와 크기에 따라 상품 목록 반환
+     */
+    @GetMapping("/products")
+    public PagedResponseDTO<ProductWithEventDTO> getProductsWithCursor(
+            @RequestParam(required = false, defaultValue = "0") Long cursor,
+            @RequestParam(defaultValue = "10") int size) {
+        return productService.getProductsWithCursor(cursor, size);
+    }
+
+
+    /**
+     * 특정 상품의 상세 정보를 조회합니다.
+     *
+     * @param productId 조회할 상품의 ID
+     * @return ProductWithEventDTO 상품의 상세 정보와 관련 이벤트 정보
+     *
+     * 예시 요청:
+     * GET /products/1
+     * 응답: ID가 1인 상품의 상세 정보 반환
+     */
+    @GetMapping("/products/{productId}")
+    public ProductWithEventDTO getProductById(@PathVariable Long productId) {
+        return productService.getProductById(productId);
+    }
+
+}

--- a/src/main/java/com/example/racetobuy/domain/order/OrderDetail.java
+++ b/src/main/java/com/example/racetobuy/domain/order/OrderDetail.java
@@ -1,6 +1,6 @@
 package com.example.racetobuy.domain.order;
 
-import com.example.racetobuy.domain.product.Product;
+import com.example.racetobuy.domain.product.entity.Product;
 import com.example.racetobuy.domain.timestamp.TimeStamp;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/example/racetobuy/domain/page/PagedResponseDTO.java
+++ b/src/main/java/com/example/racetobuy/domain/page/PagedResponseDTO.java
@@ -1,0 +1,24 @@
+package com.example.racetobuy.domain.page;
+
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PagedResponseDTO<T> {
+
+    private Long nextCursor; // 다음 커서
+    private int pageSize;    // 요청된 사이즈
+    private List<T> data;    // 데이터 리스트
+
+    public PagedResponseDTO(Long nextCursor, int pageSize, List<T> data) {
+        this.nextCursor = nextCursor;
+        this.pageSize = pageSize;
+        this.data = data;
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/racetobuy/domain/product/dto/EventInfoDTO.java
+++ b/src/main/java/com/example/racetobuy/domain/product/dto/EventInfoDTO.java
@@ -1,0 +1,12 @@
+package com.example.racetobuy.domain.product.dto;
+
+
+import java.math.BigDecimal;
+
+public record EventInfoDTO(
+        Long eventId,             // 이벤트 ID
+        String eventName,         // 이벤트 이름
+        Double discountRate,      // 할인율 (%)
+        BigDecimal discountPrice, // 할인가
+        BigDecimal priceDifference // 가격 차이 (원가 - 할인가)
+) {}

--- a/src/main/java/com/example/racetobuy/domain/product/dto/ProductWithEventDTO.java
+++ b/src/main/java/com/example/racetobuy/domain/product/dto/ProductWithEventDTO.java
@@ -1,0 +1,13 @@
+package com.example.racetobuy.domain.product.dto;
+
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record ProductWithEventDTO(
+        Long productId,          // 상품 ID
+        String productName,      // 상품 이름
+        BigDecimal price,        // 상품 가격
+        Integer stockQuantity,   // 재고 수량
+        List<EventInfoDTO> events        // 활성 이벤트 정보 (null 가능)
+) {}

--- a/src/main/java/com/example/racetobuy/domain/product/entity/Event.java
+++ b/src/main/java/com/example/racetobuy/domain/product/entity/Event.java
@@ -1,0 +1,35 @@
+package com.example.racetobuy.domain.product.entity;
+
+import com.example.racetobuy.domain.timestamp.TimeStamp;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "event")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends TimeStamp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Long eventId;
+
+    @Column(name = "event_name", nullable = false, length = 100)
+    private String eventName; // 이벤트 이름
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate; // 시작일
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDateTime endDate; // 종료일
+
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<EventProduct> eventProducts = new ArrayList<>();
+}

--- a/src/main/java/com/example/racetobuy/domain/product/entity/EventProduct.java
+++ b/src/main/java/com/example/racetobuy/domain/product/entity/EventProduct.java
@@ -1,0 +1,36 @@
+package com.example.racetobuy.domain.product.entity;
+
+import com.example.racetobuy.domain.timestamp.TimeStamp;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "event_product")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventProduct extends TimeStamp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event; // 이벤트
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product; // 상품
+
+    @Column(name = "discount_rate", nullable = false, columnDefinition = "DECIMAL(5,2)")
+    private Double discountRate; // 상품에 대한 할인율
+
+    public EventProduct(Event event, Product product, Double discountRate) {
+        this.event = event;
+        this.product = product;
+        this.discountRate = discountRate;
+    }
+}

--- a/src/main/java/com/example/racetobuy/domain/product/entity/Product.java
+++ b/src/main/java/com/example/racetobuy/domain/product/entity/Product.java
@@ -1,4 +1,4 @@
-package com.example.racetobuy.domain.product;
+package com.example.racetobuy.domain.product.entity;
 
 import com.example.racetobuy.domain.timestamp.TimeStamp;
 import jakarta.persistence.*;
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -25,10 +27,13 @@ public class Product extends TimeStamp {
     @Column(name = "product_description", columnDefinition = "TEXT")
     private String productDescription;
 
-    @Column(name = "price", nullable = false, precision = 10, scale = 2)
+    @Column(name = "price", nullable = false, columnDefinition = "DECIMAL(10,2)")
     private BigDecimal price;
 
     @Column(name = "stock_quantity", nullable = false)
     private Integer stockQuantity;
+
+    @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<EventProduct> eventProducts = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/racetobuy/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/racetobuy/domain/product/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.example.racetobuy.domain.product.repository;
+
+import com.example.racetobuy.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/example/racetobuy/domain/wishlist/Wishlist.java
+++ b/src/main/java/com/example/racetobuy/domain/wishlist/Wishlist.java
@@ -1,7 +1,7 @@
 package com.example.racetobuy.domain.wishlist;
 
 import com.example.racetobuy.domain.member.entity.Member;
-import com.example.racetobuy.domain.product.Product;
+import com.example.racetobuy.domain.product.entity.Product;
 import com.example.racetobuy.domain.timestamp.TimeStamp;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/example/racetobuy/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/racetobuy/global/constant/ErrorCode.java
@@ -33,7 +33,10 @@ public enum ErrorCode {
 
     // 서버 관련 에러 코드
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
-    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다.");
+    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다."),
+
+    //상품 관련 에러 코드
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/racetobuy/service/product/ProductService.java
+++ b/src/main/java/com/example/racetobuy/service/product/ProductService.java
@@ -1,0 +1,32 @@
+package com.example.racetobuy.service.product;
+
+import com.example.racetobuy.domain.page.PagedResponseDTO;
+import com.example.racetobuy.domain.product.dto.ProductWithEventDTO;
+
+public interface  ProductService {
+
+    /**
+     * 커서 기반 페이지네이션을 사용하여 상품 목록을 조회합니다.
+     *
+     * @param cursor 현재 페이지를 결정하는 커서 값 (0이면 첫 페이지를 의미)
+     * @param size   한 페이지에 표시할 상품 수
+     * @return PagedResponseDTO<ProductWithEventDTO> 상품 목록 및 다음 커서 정보
+     *
+     * 사용 예:
+     * - 페이지네이션을 통해 상품 데이터를 효율적으로 조회
+     * - 클라이언트는 응답에 포함된 nextCursor를 사용하여 다음 페이지 요청 가능
+     */
+    PagedResponseDTO<ProductWithEventDTO> getProductsWithCursor(Long cursor, int size);
+
+    /**
+     * 특정 상품의 상세 정보를 조회합니다.
+     *
+     * @param productId 조회할 상품의 고유 ID
+     * @return ProductWithEventDTO 상품의 상세 정보와 관련 이벤트 정보
+     *
+     * 사용 예:
+     * - 상품 상세 페이지에서 특정 상품의 데이터 및 이벤트 정보를 표시
+     * - 요청 시 존재하지 않는 상품 ID일 경우 적절한 예외 처리 필요
+     */
+    ProductWithEventDTO getProductById(Long productId);
+}

--- a/src/main/java/com/example/racetobuy/service/product/ProductServiceImpl.java
+++ b/src/main/java/com/example/racetobuy/service/product/ProductServiceImpl.java
@@ -1,0 +1,140 @@
+package com.example.racetobuy.service.product;
+
+import com.example.racetobuy.domain.page.PagedResponseDTO;
+import com.example.racetobuy.domain.product.dto.EventInfoDTO;
+import com.example.racetobuy.domain.product.dto.ProductWithEventDTO;
+import com.example.racetobuy.domain.product.entity.Event;
+import com.example.racetobuy.domain.product.entity.EventProduct;
+import com.example.racetobuy.domain.product.entity.Product;
+import com.example.racetobuy.domain.product.repository.ProductRepository;
+import com.example.racetobuy.global.constant.ErrorCode;
+import com.example.racetobuy.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProductServiceImpl implements ProductService {
+
+    private final ProductRepository productRepository;
+
+    /**
+     * 커서 기반 페이지네이션을 사용하여 상품 목록을 조회합니다.
+     *
+     * @param cursor 현재 페이지를 결정하는 커서 값 (0 이하일 경우 첫 페이지로 처리)
+     * @param size   한 페이지에 표시할 상품 수
+     * @return PagedResponseDTO<ProductWithEventDTO> 상품 목록 및 다음 커서 정보
+     *
+     * 동작 방식:
+     * - 전체 상품 데이터를 정렬하여 조회합니다.
+     * - 커서 값과 페이지 크기를 기반으로 데이터를 슬라이싱합니다.
+     * - 반환 데이터에 다음 커서를 포함하여 클라이언트가 다음 페이지를 요청할 수 있도록 합니다.
+     */
+    @Override
+    public PagedResponseDTO<ProductWithEventDTO> getProductsWithCursor(Long cursor, int size) {
+        // 커서가 0일 경우 1로 설정
+        if (cursor == null || cursor <= 0) {
+            cursor = 1L;
+        }
+
+        // 현재 커서를 계산하여 시작 위치 결정
+        int startIndex = (int) ((cursor - 1) * size);
+
+        // 데이터 전체를 정렬하여 가져오기
+        List<Product> products = productRepository.findAll(Sort.by(Sort.Direction.ASC, "productId"));
+
+        // 현재 커서에 맞는 데이터 필터링 (인덱스 기준 슬라이싱)
+        List<Product> paginatedProducts = products.stream()
+                .skip(startIndex)  // 커서 기반으로 시작점 이동
+                .limit(size)       // 사이즈만큼 데이터 가져오기
+                .collect(Collectors.toList());
+
+        // 상품 목록 -> DTO 변환
+        List<ProductWithEventDTO> productDtos = paginatedProducts.stream()
+                .map(this::mapProductToDto)
+                .collect(Collectors.toList());
+
+        // 다음 커서 계산
+        Long nextCursor = paginatedProducts.size() < size ? null : cursor + 1;
+
+        return new PagedResponseDTO<>(nextCursor, size, productDtos);
+    }
+
+    /**
+     * 특정 상품의 상세 정보를 조회합니다.
+     *
+     * @param productId 조회할 상품의 고유 ID
+     * @return ProductWithEventDTO 상품의 상세 정보와 관련 이벤트 정보
+     *
+     * 동작 방식:
+     * - 상품 ID로 상품 데이터를 조회합니다.
+     * - 상품이 존재하지 않을 경우 적절한 예외를 반환합니다.
+     */
+    @Override
+    public ProductWithEventDTO getProductById(Long productId) {
+        // 특정 상품 조회
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 상품 -> DTO 변환
+        return mapProductToDto(product);
+    }
+
+
+
+    /**
+     * 공통 매핑 로직: Product -> ProductWithEventDTO
+     *
+     * @param product 변환할 Product 엔티티
+     * @return ProductWithEventDTO 변환된 상품 DTO
+     *
+     * 동작 방식:
+     * - 상품 엔티티를 DTO로 변환합니다.
+     * - 관련된 이벤트 목록을 이벤트 DTO로 변환하여 포함합니다.
+     */
+    private ProductWithEventDTO mapProductToDto(Product product) {
+        List<EventInfoDTO> events = product.getEventProducts().stream()
+                .map(this::mapEventProductToEventInfoDto) // 이벤트 매핑 메서드 사용
+                .collect(Collectors.toList());
+
+        return new ProductWithEventDTO(
+                product.getProductId(),
+                product.getProductName(),
+                product.getPrice(),
+                product.getStockQuantity(),
+                events
+        );
+    }
+
+    /**
+     * 공통 매핑 로직: EventProduct -> EventInfoDTO
+     *
+     * @param eventProduct 변환할 EventProduct 엔티티
+     * @return EventInfoDTO 변환된 이벤트 DTO
+     *
+     * 동작 방식:
+     * - 이벤트와 상품 데이터를 사용하여 할인 가격과 차이를 계산합니다.
+     * - 이벤트 정보를 DTO로 변환하여 반환합니다.
+     */
+    private EventInfoDTO mapEventProductToEventInfoDto(EventProduct eventProduct) {
+        Event event = eventProduct.getEvent();
+        Product product = eventProduct.getProduct();
+
+        BigDecimal discountPrice = product.getPrice()
+                .multiply(BigDecimal.valueOf(1 - (eventProduct.getDiscountRate().doubleValue() / 100)));
+        BigDecimal priceDifference = product.getPrice().subtract(discountPrice);
+
+        return new EventInfoDTO(
+                event.getEventId(),
+                event.getEventName(),
+                eventProduct.getDiscountRate().doubleValue(),
+                discountPrice,
+                priceDifference
+        );
+    }
+}


### PR DESCRIPTION
- 상품이 존재하지 않을 경우 처리하기 위한 PRODUCT_NOT_FOUND 에러 코드 추가.
- `Product` 엔티티에 `EventProduct`와의 양방향 연관 관계를 설정하여 데이터 매핑 및 관리 용이성 강화.
- `ProductService`에 에러 코드를 활용한 예외 처리 로직 추가.
  - 상품 상세 조회 시 존재하지 않는 상품 ID에 대해 `BusinessException`으로 처리.
- Product 및 EventProduct 엔티티를 DTO로 변환하는 매핑 로직을 추가:
  - `ProductWithEventDTO`와 `EventInfoDTO` 변환 로직 구현.
  - 할인율을 반영한 할인가 및 가격 차이를 계산하여 이벤트 DTO에 포함.
- 커서 기반 페이지네이션 구현:
  - 커서 값과 페이지 크기를 기반으로 데이터 필터링 및 응답 구조 설정.
  - 클라이언트가 다음 페이지 요청 시 사용할 수 있도록 `nextCursor` 제공.
- 코드 가독성 및 유지보수성을 높이기 위한 Javadoc 주석 추가.