### PR TITLE
feat: 위시리스트 기능 및 에러 처리 코드 구현

### DIFF
--- a/src/main/java/com/example/racetobuy/controller/MemberController.java
+++ b/src/main/java/com/example/racetobuy/controller/MemberController.java
@@ -6,8 +6,6 @@ import com.example.racetobuy.global.constant.ErrorCode;
 import com.example.racetobuy.global.exception.BusinessException;
 import com.example.racetobuy.global.util.ApiResponse;
 import com.example.racetobuy.service.member.AuthService;
-import com.example.racetobuy.service.member.AuthServiceImpl;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/racetobuy/controller/WishlistController.java
+++ b/src/main/java/com/example/racetobuy/controller/WishlistController.java
@@ -1,0 +1,75 @@
+package com.example.racetobuy.controller;
+
+import com.example.racetobuy.domain.page.PagedResponseDTO;
+import com.example.racetobuy.domain.wishlist.dto.WishlistResponseDTO;
+import com.example.racetobuy.global.security.MemberDetails;
+import com.example.racetobuy.global.util.ApiResponse;
+import com.example.racetobuy.service.wishlist.WishlistService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/wishlist")
+public class WishlistController {
+
+    private final WishlistService wishlistService;
+
+    /**
+     * 위시리스트에 상품 추가
+     *
+     * @param productId     추가할 상품 ID
+     * @param memberDetails 인증된 사용자 정보
+     * @return WishlistResponseDTO
+     */
+    @PostMapping("/{productId}")
+    public WishlistResponseDTO addProductToWishlist(
+            @PathVariable Long productId,
+            @AuthenticationPrincipal MemberDetails memberDetails) {
+        return wishlistService.addProductToWishlist(memberDetails.getMemberId(), productId);
+    }
+
+    /**
+     * 사용자의 위시리스트 조회
+     *
+     * @param memberDetails 인증된 사용자 정보
+     * @return List<WishlistResponseDTO>
+     */
+    @GetMapping
+    public PagedResponseDTO<WishlistResponseDTO> getWishlist(@AuthenticationPrincipal MemberDetails memberDetails,
+                                                             @RequestParam(required = false, defaultValue = "0") Long cursor,
+                                                             @RequestParam(defaultValue = "10") int size) {
+        return wishlistService.getWishlist(memberDetails.getMemberId(), cursor, size);
+    }
+
+    /**
+     * 위시리스트에서 상품 제거
+     *
+     * @param productId     제거할 상품 ID
+     * @param memberDetails 인증된 사용자 정보
+     */
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ApiResponse<?>> removeProductFromWishlist(
+            @PathVariable Long productId,
+            @AuthenticationPrincipal MemberDetails memberDetails) {
+        ApiResponse<?> response = wishlistService.removeProductFromWishlist(memberDetails.getMemberId(), productId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 특정 회원의 모든 위시리스트 항목 삭제
+     * @param memberDetails 인증된 사용자 ID
+     * @return ApiResponse<Void>
+     */
+    @DeleteMapping("/delete-all")
+    public ApiResponse<?> deleteAllWishlist(@AuthenticationPrincipal MemberDetails memberDetails) {
+        return wishlistService.deleteAllByMemberMemberId(memberDetails.getMemberId());
+    }
+
+
+}

--- a/src/main/java/com/example/racetobuy/domain/member/entity/Member.java
+++ b/src/main/java/com/example/racetobuy/domain/member/entity/Member.java
@@ -2,7 +2,7 @@ package com.example.racetobuy.domain.member.entity;
 
 import com.example.racetobuy.domain.order.Order;
 import com.example.racetobuy.domain.timestamp.TimeStamp;
-import com.example.racetobuy.domain.wishlist.Wishlist;
+import com.example.racetobuy.domain.wishlist.entity.Wishlist;
 import com.example.racetobuy.global.constant.RoleToken;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/example/racetobuy/domain/page/PagedResponseDTO.java
+++ b/src/main/java/com/example/racetobuy/domain/page/PagedResponseDTO.java
@@ -8,17 +8,13 @@ import java.util.List;
 @Getter
 public class PagedResponseDTO<T> {
 
-    private Long nextCursor; // 다음 커서
+    private Long cursor; // 다음 커서
     private int pageSize;    // 요청된 사이즈
     private List<T> data;    // 데이터 리스트
 
-    public PagedResponseDTO(Long nextCursor, int pageSize, List<T> data) {
-        this.nextCursor = nextCursor;
+    public PagedResponseDTO(Long cursor, int pageSize, List<T> data) {
+        this.cursor = cursor;
         this.pageSize = pageSize;
         this.data = data;
     }
-
-
-
-
 }

--- a/src/main/java/com/example/racetobuy/domain/product/entity/Product.java
+++ b/src/main/java/com/example/racetobuy/domain/product/entity/Product.java
@@ -1,6 +1,8 @@
 package com.example.racetobuy.domain.product.entity;
 
 import com.example.racetobuy.domain.timestamp.TimeStamp;
+import com.example.racetobuy.global.constant.ErrorCode;
+import com.example.racetobuy.global.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -35,5 +37,19 @@ public class Product extends TimeStamp {
 
     @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventProduct> eventProducts = new ArrayList<>();
+
+    public void updateStockQuantity(int quantity) {
+        if (quantity < 0) {
+            throw new BusinessException(ErrorCode.INVALID_QUANTITY);
+        }
+        this.stockQuantity = quantity;
+    }
+
+    public void reduceStock(int amount) {
+        if (this.stockQuantity < amount) {
+            throw new BusinessException(ErrorCode.STOCK_NOT_ENOUGH);
+        }
+        this.stockQuantity -= amount;
+    }
 
 }

--- a/src/main/java/com/example/racetobuy/domain/wishlist/dto/WishlistResponseDTO.java
+++ b/src/main/java/com/example/racetobuy/domain/wishlist/dto/WishlistResponseDTO.java
@@ -1,0 +1,16 @@
+package com.example.racetobuy.domain.wishlist.dto;
+
+import com.example.racetobuy.domain.product.dto.EventInfoDTO;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record WishlistResponseDTO(
+        Long wishlistId,           // 위시리스트 ID
+        Long userId,               // 유저 ID
+        Long productId,            // 상품 ID
+        String productName,        // 상품 이름
+        BigDecimal price,          // 상품 가격
+        Integer stockQuantity,     // 재고 수량
+        List<EventInfoDTO> events  // 이벤트 정보
+) {}

--- a/src/main/java/com/example/racetobuy/domain/wishlist/entity/Wishlist.java
+++ b/src/main/java/com/example/racetobuy/domain/wishlist/entity/Wishlist.java
@@ -1,10 +1,11 @@
-package com.example.racetobuy.domain.wishlist;
+package com.example.racetobuy.domain.wishlist.entity;
 
 import com.example.racetobuy.domain.member.entity.Member;
 import com.example.racetobuy.domain.product.entity.Product;
 import com.example.racetobuy.domain.timestamp.TimeStamp;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,17 @@ public class Wishlist extends TimeStamp {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    /**
+     * 위시리스트 생성 메서드
+     * @param member 위시리스트 소유 회원
+     * @param product 위시리스트에 등록할 상품
+     * @return Wishlist 객체
+     */
+    @Builder
+    public static Wishlist createWishlist(Member member, Product product) {
+        Wishlist wishlist = new Wishlist();
+        wishlist.member = member;
+        wishlist.product = product;
+        return wishlist;
+    }
 }

--- a/src/main/java/com/example/racetobuy/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/example/racetobuy/domain/wishlist/repository/WishlistRepository.java
@@ -1,0 +1,45 @@
+package com.example.racetobuy.domain.wishlist.repository;
+
+import com.example.racetobuy.domain.wishlist.entity.Wishlist;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
+    /**
+     * 특정 회원과 상품 ID로 위시리스트 항목을 조회
+     *
+     * @param memberId 회원 ID
+     * @param productId 상품 ID
+     * @return 해당 위시리스트 항목 (Optional)
+     */
+    Optional<Wishlist> findByMemberMemberIdAndProductProductId(Long memberId, Long productId);
+
+    /**
+     * 특정 회원의 위시리스트를 정렬하여 조회
+     *
+     * @param memberId 회원 ID
+     * @param sort     정렬 조건
+     * @return 위시리스트 목록
+     */
+    List<Wishlist> findAllByMemberMemberId(Long memberId, Sort sort);
+
+    /**
+     * 특정 회원과 상품이 이미 위시리스트에 존재하는지 확인
+     *
+     * @param memberId 회원 ID
+     * @param productId 상품 ID
+     * @return 존재 여부 (boolean)
+     */
+    boolean existsByMemberMemberIdAndProductProductId(Long memberId, Long productId);
+    /**
+     * 특정 회원의 모든 위시리스트 항목 삭제
+     *
+     * @param memberId 회원 ID
+     */
+    void deleteAllByMember_MemberId(Long memberId);
+}

--- a/src/main/java/com/example/racetobuy/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/racetobuy/global/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
         configuration.addAllowedMethod("*"); // GET, POST, PUT, DELETE (Javascript 요청 허용)
         configuration.addAllowedOriginPattern("*"); // 모든 IP 주소 허용 (프론트 앤드 IP만 허용 react)
         configuration.setAllowCredentials(true); // 클라이언트에서 쿠키 요청 허용
-//        configuration.addExposedHeader("Authorization"); // 옛날에는 디폴트 였다. 지금은 아닙니다.
+        configuration.addExposedHeader("Authorization"); // 옛날에는 디폴트 였다. 지금은 아닙니다.
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
 

--- a/src/main/java/com/example/racetobuy/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/racetobuy/global/constant/ErrorCode.java
@@ -36,7 +36,19 @@ public enum ErrorCode {
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다."),
 
     //상품 관련 에러 코드
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다.");
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+
+
+    // 위시리스트 관련 에러
+    WISHLIST_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "위시리스트에서 해당 항목을 찾을 수 없습니다."),
+    PRODUCT_ALREADY_IN_WISHLIST(HttpStatus.CONFLICT, "해당 상품이 이미 위시리스트에 존재합니다."),
+
+    // 재고 관련 에러
+    STOCK_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "상품의 재고가 부족합니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "수량은 0보다 커야 합니다."),
+
+    ;
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/racetobuy/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/racetobuy/global/security/JwtTokenProvider.java
@@ -12,7 +12,6 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.security.SignatureException;
 import java.util.Date;
 
 

--- a/src/main/java/com/example/racetobuy/service/product/ProductServiceImpl.java
+++ b/src/main/java/com/example/racetobuy/service/product/ProductServiceImpl.java
@@ -29,7 +29,7 @@ public class ProductServiceImpl implements ProductService {
      * @param cursor 현재 페이지를 결정하는 커서 값 (0 이하일 경우 첫 페이지로 처리)
      * @param size   한 페이지에 표시할 상품 수
      * @return PagedResponseDTO<ProductWithEventDTO> 상품 목록 및 다음 커서 정보
-     *
+     * <p>
      * 동작 방식:
      * - 전체 상품 데이터를 정렬하여 조회합니다.
      * - 커서 값과 페이지 크기를 기반으로 데이터를 슬라이싱합니다.
@@ -60,9 +60,8 @@ public class ProductServiceImpl implements ProductService {
                 .collect(Collectors.toList());
 
         // 다음 커서 계산
-        Long nextCursor = paginatedProducts.size() < size ? null : cursor + 1;
 
-        return new PagedResponseDTO<>(nextCursor, size, productDtos);
+        return new PagedResponseDTO<>(cursor, size, productDtos);
     }
 
     /**
@@ -70,7 +69,7 @@ public class ProductServiceImpl implements ProductService {
      *
      * @param productId 조회할 상품의 고유 ID
      * @return ProductWithEventDTO 상품의 상세 정보와 관련 이벤트 정보
-     *
+     * <p>
      * 동작 방식:
      * - 상품 ID로 상품 데이터를 조회합니다.
      * - 상품이 존재하지 않을 경우 적절한 예외를 반환합니다.
@@ -86,13 +85,12 @@ public class ProductServiceImpl implements ProductService {
     }
 
 
-
     /**
      * 공통 매핑 로직: Product -> ProductWithEventDTO
      *
      * @param product 변환할 Product 엔티티
      * @return ProductWithEventDTO 변환된 상품 DTO
-     *
+     * <p>
      * 동작 방식:
      * - 상품 엔티티를 DTO로 변환합니다.
      * - 관련된 이벤트 목록을 이벤트 DTO로 변환하여 포함합니다.
@@ -116,7 +114,7 @@ public class ProductServiceImpl implements ProductService {
      *
      * @param eventProduct 변환할 EventProduct 엔티티
      * @return EventInfoDTO 변환된 이벤트 DTO
-     *
+     * <p>
      * 동작 방식:
      * - 이벤트와 상품 데이터를 사용하여 할인 가격과 차이를 계산합니다.
      * - 이벤트 정보를 DTO로 변환하여 반환합니다.

--- a/src/main/java/com/example/racetobuy/service/wishlist/WishlistService.java
+++ b/src/main/java/com/example/racetobuy/service/wishlist/WishlistService.java
@@ -1,0 +1,41 @@
+package com.example.racetobuy.service.wishlist;
+
+import com.example.racetobuy.domain.page.PagedResponseDTO;
+import com.example.racetobuy.domain.wishlist.dto.WishlistResponseDTO;
+import com.example.racetobuy.global.util.ApiResponse;
+
+public interface WishlistService {
+
+    /**
+     * 위시리스트에 상품 추가
+     *
+     * @param memberId  회원 ID
+     * @param productId 상품 ID
+     * @return WishlistResponseDTO
+     */
+    WishlistResponseDTO addProductToWishlist(Long memberId, Long productId);
+
+    /**
+     * 위시리스트에서 상품 제거
+     *
+     * @param memberId  회원 ID
+     * @param productId 상품 ID
+     */
+    ApiResponse<?> removeProductFromWishlist(Long memberId, Long productId);
+
+    /**
+     * 회원의 위시리스트 조회
+     *
+     * @param memberId 회원 ID
+     * @return 위시리스트 리스트
+     */
+    PagedResponseDTO<WishlistResponseDTO> getWishlist(Long memberId, Long cursor, int size);
+
+    /**
+     * 특정 회원의 모든 위시리스트 항목 삭제
+     *
+     * @param memberId 회원 ID
+     * @return ApiResponse<Void>
+     */
+    ApiResponse<?> deleteAllByMemberMemberId(Long memberId);
+}

--- a/src/main/java/com/example/racetobuy/service/wishlist/WishlistServiceImpl.java
+++ b/src/main/java/com/example/racetobuy/service/wishlist/WishlistServiceImpl.java
@@ -1,0 +1,157 @@
+package com.example.racetobuy.service.wishlist;
+
+import com.example.racetobuy.domain.member.entity.Member;
+import com.example.racetobuy.domain.page.PagedResponseDTO;
+import com.example.racetobuy.domain.product.dto.EventInfoDTO;
+import com.example.racetobuy.domain.product.entity.Product;
+import com.example.racetobuy.domain.product.repository.ProductRepository;
+import com.example.racetobuy.domain.wishlist.dto.WishlistResponseDTO;
+import com.example.racetobuy.domain.wishlist.entity.Wishlist;
+import com.example.racetobuy.domain.wishlist.repository.WishlistRepository;
+import com.example.racetobuy.global.constant.ErrorCode;
+import com.example.racetobuy.global.exception.BusinessException;
+import com.example.racetobuy.global.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class WishlistServiceImpl implements WishlistService {
+
+    private final WishlistRepository wishlistRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    public WishlistResponseDTO addProductToWishlist(Long memberId, Long productId) {
+        // 상품 조회
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 중복 체크
+        if (wishlistRepository.existsByMemberMemberIdAndProductProductId(memberId, productId)) {
+            throw new BusinessException(ErrorCode.PRODUCT_ALREADY_IN_WISHLIST);
+        }
+
+        // 위시리스트 저장
+        Wishlist wishlist = Wishlist.createWishlist(
+                Member.builder().memberId(memberId).build(), product
+        );
+
+        wishlistRepository.save(wishlist);
+
+        // WishlistResponseDTO 반환
+        return new WishlistResponseDTO(
+                wishlist.getWishlistId(),
+                memberId,
+                product.getProductId(),
+                product.getProductName(),
+                product.getPrice(),
+                product.getStockQuantity(),
+                product.getEventProducts().stream()
+                        .map(eventProduct -> new EventInfoDTO(
+                                eventProduct.getEvent().getEventId(),
+                                eventProduct.getEvent().getEventName(),
+                                eventProduct.getDiscountRate().doubleValue(),
+                                product.getPrice()
+                                        .multiply(BigDecimal.valueOf(eventProduct.getDiscountRate().doubleValue())
+                                                .divide(BigDecimal.valueOf(100))),
+                                product.getPrice()
+                                        .subtract(product.getPrice()
+                                                .multiply(BigDecimal.valueOf(eventProduct.getDiscountRate().doubleValue())
+                                                        .divide(BigDecimal.valueOf(100))))
+                        ))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public ApiResponse<?> removeProductFromWishlist(Long memberId, Long productId) {
+        Wishlist wishlist = wishlistRepository.findByMemberMemberIdAndProductProductId(memberId, productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WISHLIST_ITEM_NOT_FOUND));
+
+        wishlistRepository.delete(wishlist);
+
+        return ApiResponse.success("위시리스트 삭제가 완료 됐습니다.");
+    }
+
+    @Override
+    public PagedResponseDTO<WishlistResponseDTO> getWishlist(Long memberId, Long cursor, int size) {
+        // 커서가 0일 경우 1로 설정
+        if (cursor == null || cursor <= 0) {
+            cursor = 1L;
+        }
+
+        // 현재 커서를 계산하여 시작 위치 결정
+        int startIndex = (int) ((cursor - 1) * size);
+
+        // 회원의 위시리스트 조회 및 정렬
+        List<Wishlist> wishlists = wishlistRepository.findAllByMemberMemberId(memberId, Sort.by(Sort.Direction.ASC, "wishlistId"));
+
+        // 현재 커서에 맞는 데이터 필터링 (인덱스 기준 슬라이싱)
+        List<Wishlist> paginatedWishlists = wishlists.stream()
+                .skip(startIndex)  // 커서 기반으로 시작점 이동
+                .limit(size)       // 사이즈만큼 데이터 가져오기
+                .toList();
+
+        // Wishlist -> WishlistResponseDTO 변환
+        List<WishlistResponseDTO> wishlistDtos = paginatedWishlists.stream()
+                .map(wishlist -> {
+                    Product product = wishlist.getProduct();
+
+                    List<EventInfoDTO> events = product.getEventProducts().stream()
+                            .map(eventProduct -> {
+                                BigDecimal discountRate = BigDecimal.valueOf(eventProduct.getDiscountRate().doubleValue())
+                                        .divide(BigDecimal.valueOf(100));
+
+                                BigDecimal discountPrice = product.getPrice().multiply(BigDecimal.ONE.subtract(discountRate));
+                                BigDecimal priceDifference = product.getPrice().subtract(discountPrice);
+
+                                return new EventInfoDTO(
+                                        eventProduct.getEvent().getEventId(),
+                                        eventProduct.getEvent().getEventName(),
+                                        eventProduct.getDiscountRate().doubleValue(),
+                                        discountPrice,
+                                        priceDifference
+                                );
+                            }).collect(Collectors.toList());
+
+                    return new WishlistResponseDTO(
+                            wishlist.getWishlistId(),
+                            wishlist.getMember().getMemberId(),
+                            product.getProductId(),
+                            product.getProductName(),
+                            product.getPrice(),
+                            product.getStockQuantity(),
+                            events
+                    );
+                })
+                .collect(Collectors.toList());
+
+        // 다음 커서 계산
+
+        return new PagedResponseDTO<>(cursor, size, wishlistDtos);
+    }
+
+    @Override
+    @Transactional
+    public ApiResponse<?> deleteAllByMemberMemberId(Long memberId) {
+        // 방어 로직: memberId 유효성 검사
+        if (memberId == null || memberId < 0) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        // 위시리스트 삭제
+        try {
+            wishlistRepository.deleteAllByMember_MemberId(memberId);
+            return ApiResponse.success( "위시리스트의 모든 항목이 삭제되었습니다.");
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}


### PR DESCRIPTION
### 변경 사항
- `ErrorCode`에 위시리스트 관련 에러 코드 추가
  - `WISHLIST_ITEM_NOT_FOUND`
  - `PRODUCT_ALREADY_IN_WISHLIST`
- `WishlistController` 구현
  - 상품 추가: `addProductToWishlist`
  - 조회: `getWishlist`
  - 삭제: `removeProductFromWishlist`
  - 모든 항목 삭제: `deleteAllWishlist`
- `WishlistRepository` 인터페이스 구현
  - 회원 및 상품 기반 조회: `findByMemberMemberIdAndProductProductId`
  - 회원 기반 정렬 조회: `findAllByMemberMemberId`
  - 모든 항목 삭제: `deleteAllByMember_MemberId`
- `WishlistResponseDTO` 정의
  - 위시리스트 응답 데이터 구조 설계
- `WishlistService` 및 `WishlistServiceImpl` 구현
  - 위시리스트 추가, 조회, 삭제 기능
  - 이벤트 정보 포함
  - 페이지네이션 처리

### 추가 정보
- 비즈니스 예외 처리 로직 추가
- 도메인 메서드 (`existsBy`, `findAllBy`, `deleteAllBy`) 구현

Ref: #15